### PR TITLE
Support passing a callback to "add"

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,13 @@
 
 		this.items.push(newItem);
 	};
+	
+	Root.prototype.destroy = function () {
+		if (this.watcher) {
+			this.items = []
+			this.watcher.destroy()
+		}
+	}
 
 	return {
 		create: function (item, offsets, container) {

--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@
 		this.callback = callback;
 	}
 	
-	CallbackParallax.prototype.handleScroll = function (ratio, distance) {
-		this.callback(ratio, distance)
+	CallbackParallax.prototype.handleScroll = function (ratio, distance, watcher) {
+		this.callback(ratio, distance, watcher)
 	};
 	
 	function OptionsParallax (element, options, container) {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,15 @@
 		return getNumber(easing, start, end, ratio);
 	}
 
+	function CallbackParallax (element, callback) {
+		this.element = element;
+		this.callback = callback;
+	}
+	
+	CallbackParallax.prototype.handleScroll = function (ratio, distance) {
+		this.callback(ratio, distance)
+	};
+	
 	function OptionsParallax (element, options, container) {
 		container = container || scrollMonitor;
 		this.options = options;
@@ -144,6 +153,8 @@
 		var newItem;
 		if (typeof optionsOrSpeed === 'number') {
 			newItem = new SpeedParallax(element, optionsOrSpeed);
+		} else if (typeof optionsOrSpeed === 'function') {
+			newItem = new CallbackParallax(element, optionsOrSpeed);
 		} else {
 			newItem = new OptionsParallax(element, optionsOrSpeed, this.container);
 		}


### PR DESCRIPTION
This adds support for passing a callback to `add`.  My use case is wanting to use this library with Vue.js where I want to use Vue to set style attributes on the parallaxed element.  I'm using like:

```js
var parallaxRoot = parallax.create(domElement);
parallaxRoot.add(domElement, function(ratio) {
  // Store the ratio in the Vue component
});
```

Also, this PR adds a `destroy()` method.